### PR TITLE
Using `console.error` instead of  `console.log` to print to stderr

### DIFF
--- a/src/handlers/ConsoleHandler.ts
+++ b/src/handlers/ConsoleHandler.ts
@@ -2,7 +2,7 @@ import Handler from '../Handler';
 
 class ConsoleHandler extends Handler {
   public emit(output: string): void {
-    console.log(output);
+    console.error(output);
   }
 }
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -6,7 +6,7 @@ describe('index', () => {
     jest.clearAllMocks();
   });
   test('Testing basic usage of the logger', () => {
-    const consoleSpy = jest.spyOn(console, 'log');
+    const consoleSpy = jest.spyOn(console, 'error');
     const logger = new Logger('root');
     logger.debug('DEBUG MESSAGE');
     expect(consoleSpy).toHaveBeenCalledWith('DEBUG:root:DEBUG MESSAGE');
@@ -33,7 +33,7 @@ describe('index', () => {
     jest
       .useFakeTimers('modern')
       .setSystemTime(new Date('2020-01-01').getTime());
-    const consoleSpy = jest.spyOn(console, 'log');
+    const consoleSpy = jest.spyOn(console, 'error');
     const logger = new Logger('root', LogLevel.NOTSET, [
       new ConsoleHandler(
         formatting.format`${formatting.date}:${formatting.msg}`,
@@ -57,7 +57,7 @@ describe('index', () => {
     );
   });
   test('Testing logger hierarchy', () => {
-    const consoleSpy = jest.spyOn(console, 'log');
+    const consoleSpy = jest.spyOn(console, 'error');
     const logger = new Logger('root');
     const childLogger = logger.getChild('child');
     childLogger.debug('DEBUG MESSAGE');
@@ -70,7 +70,7 @@ describe('index', () => {
     expect(consoleSpy).toHaveBeenCalledWith('ERROR:child:ERROR MESSAGE');
   });
   test('Testing logger level hierarchy', () => {
-    const consoleSpy = jest.spyOn(console, 'log');
+    const consoleSpy = jest.spyOn(console, 'error');
     const logger = new Logger('root', LogLevel.WARN);
     const childLogger = logger.getChild('child');
     childLogger.debug('DEBUG MESSAGE');
@@ -88,7 +88,7 @@ describe('index', () => {
     expect(consoleSpy).toHaveBeenCalledWith('INFO:child:INFO MESSAGE');
   });
   test('Testing logger hierarchy with keys format', () => {
-    const consoleSpy = jest.spyOn(console, 'log');
+    const consoleSpy = jest.spyOn(console, 'error');
     const logger = new Logger('root', LogLevel.NOTSET, [
       new ConsoleHandler(
         formatting.format`${formatting.level}:${formatting.keys}:${formatting.msg}`,
@@ -102,7 +102,7 @@ describe('index', () => {
     jest
       .useFakeTimers('modern')
       .setSystemTime(new Date('2020-01-01').getTime());
-    const consoleSpy = jest.spyOn(console, 'log');
+    const consoleSpy = jest.spyOn(console, 'error');
     const logger = new Logger('root', LogLevel.NOTSET, [
       new ConsoleHandler(
         formatting.format`${formatting.date}:${formatting.msg}${formatting.trace}`,
@@ -115,7 +115,7 @@ describe('index', () => {
     expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('at'));
   });
   test('Testing overriding log format', () => {
-    const consoleSpy = jest.spyOn(console, 'log');
+    const consoleSpy = jest.spyOn(console, 'error');
     const logger = new Logger('root', LogLevel.NOTSET);
     logger.debug('DEBUG MESSAGE', formatting.format`OVERRIDDEN`);
     expect(consoleSpy).toHaveBeenCalledWith('OVERRIDDEN');


### PR DESCRIPTION
### Description
<!-- Write your description about what this PR is about. -->
Switching from `console.log` to `console.error` in order to log to stderr rather than stdout.

### Tasks
<!-- 
  List all tasks to be done by this PR.
  If a task is no longer required, add a strikethrough (including the checkbox):
  - ~~[ ] 3. ...~~ - being completed in #...
-->
- [x] 1. Switch `console.log` in `ConsoleHandler.ts` to `console.error`
- [x] 2. Change console spies in tests to spy on `error` instead of `log`

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
