### PR TITLE
Trace and optional formatting

### DIFF
--- a/src/Handler.ts
+++ b/src/Handler.ts
@@ -13,8 +13,8 @@ abstract class Handler {
     this.formatter = formatter;
   }
 
-  public handle(record: LogRecord): void {
-    const output = this.format(record);
+  public handle(record: LogRecord, format?: LogFormatter): void {
+    const output = format != null ? format(record) : this.format(record);
     this.emit(output);
   }
 

--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -1,4 +1,4 @@
-import type { ToString, LogRecord } from './types';
+import type { ToString, LogRecord, LogFormatter } from './types';
 import type Handler from './Handler';
 
 import { LogLevel } from './types';
@@ -74,26 +74,26 @@ class Logger {
     }
   }
 
-  public debug(data: ToString): void {
-    this.log(data.toString(), LogLevel.DEBUG);
+  public debug(data: ToString, format?: LogFormatter): void {
+    this.log(data.toString(), LogLevel.DEBUG, format);
   }
 
-  public info(data: ToString): void {
-    this.log(data.toString(), LogLevel.INFO);
+  public info(data: ToString, format?: LogFormatter): void {
+    this.log(data.toString(), LogLevel.INFO, format);
   }
 
-  public warn(data: ToString): void {
-    this.log(data.toString(), LogLevel.WARN);
+  public warn(data: ToString, format?: LogFormatter): void {
+    this.log(data.toString(), LogLevel.WARN, format);
   }
 
-  public error(data: ToString): void {
-    this.log(data.toString(), LogLevel.ERROR);
+  public error(data: ToString, format?: LogFormatter): void {
+    this.log(data.toString(), LogLevel.ERROR, format);
   }
 
-  protected log(msg: string, level: LogLevel): void {
+  protected log(msg: string, level: LogLevel, format?: LogFormatter): void {
     const record = this.makeRecord(msg, level);
     if (level >= this.getEffectiveLevel()) {
-      this.callHandlers(record);
+      this.callHandlers(record, format);
     }
   }
 
@@ -107,12 +107,12 @@ class Logger {
     };
   }
 
-  protected callHandlers(record: LogRecord): void {
+  protected callHandlers(record: LogRecord, format?: LogFormatter): void {
     for (const handler of this.handlers) {
-      handler.handle(record);
+      handler.handle(record, format);
     }
     if (this.parent) {
-      this.parent.callHandlers(record);
+      this.parent.callHandlers(record, format);
     }
   }
 }

--- a/src/formatting.ts
+++ b/src/formatting.ts
@@ -34,9 +34,19 @@ function format(
       } else if (value === level) {
         result += levelToString(record.level);
       } else if (value === trace) {
-        const errorStack = new Error().stack ?? '';
-        const formattedStack = errorStack.split('\n').splice(7).join('\n');
-        result += '\n' + formattedStack;
+        const errorStack = new Error().stack;
+        if (errorStack != null) {
+          const splitErrorStack = errorStack.split('\n');
+          const position =
+            splitErrorStack.findIndex((value) => /Logger\.log/.test(value)) ??
+            0;
+          const formattedStack = splitErrorStack
+            .splice(position + 2)
+            .join('\n');
+          result += '\n' + formattedStack;
+        } else {
+          result += '';
+        }
       } else {
         result += value.toString();
       }

--- a/src/formatting.ts
+++ b/src/formatting.ts
@@ -7,6 +7,7 @@ const key = Symbol('key');
 const keys = Symbol('keys');
 const date = Symbol('date');
 const msg = Symbol('msg');
+const trace = Symbol('trace');
 
 function format(
   strings: TemplateStringsArray,
@@ -32,6 +33,10 @@ function format(
         result += record.msg;
       } else if (value === level) {
         result += levelToString(record.level);
+      } else if (value === trace) {
+        const errorStack = new Error().stack ?? '';
+        const formattedStack = errorStack.split('\n').splice(7).join('\n');
+        result += '\n' + formattedStack;
       } else {
         result += value.toString();
       }
@@ -43,4 +48,4 @@ function format(
 
 const formatter = format`${level}:${key}:${msg}`;
 
-export { level, key, keys, date, msg, format, formatter };
+export { level, key, keys, date, msg, trace, format, formatter };

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -114,4 +114,16 @@ describe('index', () => {
     );
     expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('at'));
   });
+  test('Testing overriding log format', () => {
+    const consoleSpy = jest.spyOn(console, 'log');
+    const logger = new Logger('root', LogLevel.NOTSET);
+    logger.debug('DEBUG MESSAGE', formatting.format`OVERRIDDEN`);
+    expect(consoleSpy).toHaveBeenCalledWith('OVERRIDDEN');
+    logger.info('INFO MESSAGE', formatting.format`OVERRIDDEN`);
+    expect(consoleSpy).toHaveBeenCalledWith('OVERRIDDEN');
+    logger.warn('WARN MESSAGE', formatting.format`OVERRIDDEN`);
+    expect(consoleSpy).toHaveBeenCalledWith('OVERRIDDEN');
+    logger.error('ERROR MESSAGE', formatting.format`OVERRIDDEN`);
+    expect(consoleSpy).toHaveBeenCalledWith('OVERRIDDEN');
+  });
 });

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -98,4 +98,20 @@ describe('index', () => {
     childLogger.debug('DEBUG MESSAGE');
     expect(consoleSpy).toHaveBeenCalledWith('DEBUG:root.child:DEBUG MESSAGE');
   });
+  test('Testing logger trace', () => {
+    jest
+      .useFakeTimers('modern')
+      .setSystemTime(new Date('2020-01-01').getTime());
+    const consoleSpy = jest.spyOn(console, 'log');
+    const logger = new Logger('root', LogLevel.NOTSET, [
+      new ConsoleHandler(
+        formatting.format`${formatting.date}:${formatting.msg}${formatting.trace}`,
+      ),
+    ]);
+    logger.debug('DEBUG MESSAGE');
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('2020-01-01T00:00:00.000Z:DEBUG MESSAGE'),
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('at'));
+  });
 });


### PR DESCRIPTION
### Description
<!-- Write your description about what this PR is about. -->
This adds a `trace` key to the formatter. this when added to the end of the format will print out a error like stack trace in the log message. Note that this breaks the one message per line log convention and should only be used for debugging.

This PR also adds an optional format override to a log message. So now you can change the log formmat on a per-message basis. You can do this by doing.
```ts
logger.info('message', formatter.format`new format ${formatter.msg}${formatter.trace}`);
```

### Issues Fixed
<!-- List all issues fixed by this PR. -->
* Fixes #4

### Tasks
<!-- 
  List all tasks to be done by this PR.
  If a task is no longer required, add a strikethrough (including the checkbox):
  - ~~[ ] 3. ...~~ - being completed in #...
-->
- [x] 1. add a `trace` key to the formatter.
- [x] 2. add an optional format override to each logger method.

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
