### PR TITLE
Reduce redundancy in the span format

### DIFF
--- a/src/tracer/Tracer.ts
+++ b/src/tracer/Tracer.ts
@@ -7,6 +7,7 @@ class Tracer {
   protected resolveWaitChunksP: (() => void) | undefined;
   protected ended: boolean = false;
   protected idGen = new IdSortable();
+  protected shouldTrace = false;
 
   protected nextId(): SpanId {
     const result = this.idGen.next();
@@ -16,7 +17,8 @@ class Tracer {
     return result.value.toMultibase('base32hex') as SpanId;
   }
 
-  protected queueSpanEvent(evt: SpanEvent) {
+  protected queueSpanEvent(evt: SpanEvent): void {
+    if (!this.shouldTrace) return;
     this.queue.push(evt);
     if (this.resolveWaitChunksP != null) this.resolveWaitChunksP();
   }
@@ -74,6 +76,13 @@ class Tracer {
       }
       yield value;
     }
+  }
+
+  public disableTracing(): void {
+    this.shouldTrace = false;
+    this.ended = true;
+    this.resolveWaitChunksP?.();
+    this.queue = [];
   }
 }
 

--- a/src/tracer/Tracer.ts
+++ b/src/tracer/Tracer.ts
@@ -1,19 +1,19 @@
-import type { SpanEvent } from './types.js';
-import { IdSortable, utils as idUtils } from '@matrixai/id';
+import type { SpanEvent, SpanId } from './types.js';
+import { IdSortable } from '@matrixai/id';
 
 class Tracer {
-  protected activeSpans: Map<string, string> = new Map();
+  protected activeSpans: Map<SpanId, string> = new Map();
   protected queue: Array<SpanEvent> = [];
   protected resolveWaitChunksP: (() => void) | undefined;
   protected ended: boolean = false;
   protected idGen = new IdSortable();
 
-  protected nextId(): string {
+  protected nextId(): SpanId {
     const result = this.idGen.next();
     if (result.done || result.value == null) {
       throw new Error('Unexpected end of id generator');
     }
-    return idUtils.toMultibase(result.value, 'base64');
+    return result.value.toMultibase('base32hex');
   }
 
   protected queueSpanEvent(evt: SpanEvent) {
@@ -21,28 +21,26 @@ class Tracer {
     if (this.resolveWaitChunksP != null) this.resolveWaitChunksP();
   }
 
-  public startSpan(name: string, parentSpanId?: string): string {
+  public startSpan(name: string, parentSpanId?: SpanId): SpanId {
     const spanId = this.nextId();
     this.activeSpans.set(spanId, name);
     this.queueSpanEvent({
       type: 'start',
-      id: this.nextId(),
-      spanId: spanId,
-      parentSpanId: parentSpanId,
+      id: spanId,
+      parentId: parentSpanId,
       name: name,
     });
     return spanId;
   }
 
-  public endSpan(spanId: string): void {
+  public endSpan(spanId: SpanId): void {
     const name = this.activeSpans.get(spanId);
     if (!name) return;
     this.activeSpans.delete(spanId);
     this.queueSpanEvent({
-      type: 'end',
+      type: 'stop',
       id: this.nextId(),
-      spanId: spanId,
-      name: name,
+      startId: spanId,
     });
   }
 

--- a/src/tracer/Tracer.ts
+++ b/src/tracer/Tracer.ts
@@ -13,7 +13,7 @@ class Tracer {
     if (result.done || result.value == null) {
       throw new Error('Unexpected end of id generator');
     }
-    return result.value.toMultibase('base32hex');
+    return result.value.toMultibase('base32hex') as SpanId;
   }
 
   protected queueSpanEvent(evt: SpanEvent) {
@@ -46,7 +46,7 @@ class Tracer {
 
   public async traced<T>(
     name: string,
-    parentSpanId: string | undefined,
+    parentSpanId: SpanId | undefined,
     fn: () => T | Promise<T>,
   ): Promise<T> {
     const fnProm = async () => {

--- a/src/tracer/types.ts
+++ b/src/tracer/types.ts
@@ -1,12 +1,26 @@
-type Span = {
-  spanId: string;
-  name: string;
-  parentSpanId?: string;
+type SpanId = string;
+
+/**
+ * A span is a virtual concept, not an actual object. A span is made up of
+ * multiple events. Each event gets its own ID. Each start event must be
+ * associated with a stop event, otherwise the span is considered to be
+ * ongoing.
+ */
+
+type SpanStart = {
+  type: 'start';
+  id: SpanId;
+  parentId?: SpanId;
+  name?: string;
 };
 
-type SpanEvent = Span & {
-  type: 'start' | 'end';
-  id: string;
+type SpanStop = {
+  type: 'stop';
+  id: SpanId;
+  startId: SpanId;
+  parentId?: SpanId;
 };
 
-export type { Span, SpanEvent };
+type SpanEvent = SpanStart | SpanStop;
+
+export type { SpanId, SpanEvent };

--- a/src/tracer/types.ts
+++ b/src/tracer/types.ts
@@ -1,4 +1,4 @@
-type SpanId = string;
+type SpanId = string & { readonly brand: unique symbol };
 
 /**
  * A span is a virtual concept, not an actual object. A span is made up of

--- a/tests/asciinemaTest.ts
+++ b/tests/asciinemaTest.ts
@@ -1,10 +1,11 @@
+import type { SpanId } from '#tracer/index.js';
 import fs from 'fs';
 import * as fc from 'fast-check';
 import tracer from '#tracer/index.js';
 
 let parentIndex = 0;
 let step = 0;
-let nestedIds: Array<string> = [];
+let nestedIds: Array<SpanId> = [];
 
 type Flags = {
   hasForkA: boolean;
@@ -18,9 +19,9 @@ type Flags = {
 };
 
 const current: {
-  parentId?: string;
-  forkAId?: string;
-  forkBId?: string;
+  parentId?: SpanId;
+  forkAId?: SpanId;
+  forkBId?: SpanId;
   flags: Flags;
 } = {
   flags: {


### PR DESCRIPTION
### Description
<!-- Write your description about what this PR is about. -->

Cleans up the span format by using consistent event types (start/stop) and converts the span ID into `base32hex` to align with node IDs in Polykey.

### Issues Fixed
<!-- List all issues fixed by this PR. -->
* Fixes #60 

### Tasks
<!-- 
  List all tasks to be done by this PR.
  If a task is no longer required, add a strikethrough (including the checkbox):
  - ~~[ ] 3. ...~~ - being completed in #...
-->
- [x] 1. Change ID format from `base64` to `base32hex`
- [x] 2. Change types from `start/end` to `start/stop`
- [x] 3. Reduce redundancy of information in span format

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
